### PR TITLE
Pass UWSGI_EXTRA arguments after --plugins python3 argument

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -18,6 +18,6 @@ ENV PGSERVICEFILE="/srv/pg_service.conf"
 STOPSIGNAL SIGINT
 
 ENTRYPOINT uwsgi --http-socket :9090 --buffer-size $REQ_HEADER_BUFFER_SIZE --processes $UWSGI_PROCESSES \
-    --threads $UWSGI_THREADS $UWSGI_EXTRA --plugins python3 --protocol uwsgi --wsgi-disable-file-wrapper \
+    --threads $UWSGI_THREADS --plugins python3 $UWSGI_EXTRA --protocol uwsgi --wsgi-disable-file-wrapper \
     --uid $SERVICE_UID --gid $SERVICE_GID --master --chdir /srv/qwc_service --mount $SERVICE_MOUNTPOINT=server:app \
     --manage-script-name

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -23,6 +23,6 @@ ENV PGSERVICEFILE="/srv/pg_service.conf"
 STOPSIGNAL SIGINT
 
 ENTRYPOINT uwsgi --http-socket :9090 --buffer-size $REQ_HEADER_BUFFER_SIZE --processes $UWSGI_PROCESSES \
-    --threads $UWSGI_THREADS $UWSGI_EXTRA --plugins python3 --protocol uwsgi --wsgi-disable-file-wrapper \
+    --threads $UWSGI_THREADS --plugins python3 $UWSGI_EXTRA --protocol uwsgi --wsgi-disable-file-wrapper \
     --uid $SERVICE_UID --gid $SERVICE_GID --master --chdir /srv/qwc_service --mount $SERVICE_MOUNTPOINT=server:app \
     --manage-script-name


### PR DESCRIPTION
This is needed to add plugin options like `--py-autoreload=1` otherwise it is not recognized by uwsgi