### PR TITLE
Fix: optional uid gid

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,53 @@
 [![CI](https://github.com/qwc-services/qwc-uwsgi-base/actions/workflows/uwsgi-base.yml/badge.svg)](https://github.com/qwc-services/qwc-uwsgi-base/actions)
 [![docker](https://img.shields.io/docker/v/sourcepole/qwc-uwsgi-base?label=qwc-uwsgi-base%20image&sort=semver)](https://hub.docker.com/r/sourcepole/qwc-uwsgi-base)
 
-QWC uWSGI Base
-==============
+# QWC uWSGI Base
 
 QWC docker uWSGI base images for QWC services.
 
 Multiple environment variables are available:
 
-| Variable | Description | Default value |
-| -------- | ----------- | ------------- |
-| `LOCALE` | For the ubuntu-based `qwc-uwsgi-base`, defines the runtime locale in the form `lang_COUNTRY` (i.e. `de_CH`) | `en_US` |
-| `PGSERVICEFILE` | Path to pg_service.conf file | `/srv/pg_service.conf` |
-| `REQ_HEADER_BUFFER_SIZE` | Internal [uWSGI buffer size](http://uwsgi-docs.readthedocs.io/en/latest/Options.html#buffer-size) | `12288` |
-| `SERVICE_GID` | GID used for running the service | `33` |
-| `SERVICE_MOUNTPOINT` | Route from which the service will be mounted (e.g. `/api/v1/feature-info`) | `/` |
-| `SERVICE_UID` | UID used for running the service | `33` |
-| `UV_COMPILE_BYTECODE` | Enable UV byte code compilation | `1` |
-| `UWSGI_EXTRA` | Extra parameter to pass to uWSGI command line - see below | empty |
-| `UWSGI_PROCESSES` | Number of uWSGI processes to spawn | `1` |
-| `UWSGI_THREADS` | Number of uWSGI threads for each processes | `4` |
+| Variable                 | Description                                                                                                 | Default value          |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------- | ---------------------- |
+| `LOCALE`                 | For the ubuntu-based `qwc-uwsgi-base`, defines the runtime locale in the form `lang_COUNTRY` (i.e. `de_CH`) | `en_US`                |
+| `PGSERVICEFILE`          | Path to pg_service.conf file                                                                                | `/srv/pg_service.conf` |
+| `REQ_HEADER_BUFFER_SIZE` | Internal [uWSGI buffer size](http://uwsgi-docs.readthedocs.io/en/latest/Options.html#buffer-size)           | `12288`                |
+| `SERVICE_GID`            | GID used for running the service; if explicitly set to an empty value, `--gid` is not passed to uWSGI       | `33`                   |
+| `SERVICE_MOUNTPOINT`     | Route from which the service will be mounted (e.g. `/api/v1/feature-info`)                                  | `/`                    |
+| `SERVICE_UID`            | UID used for running the service; if explicitly set to an empty value, `--uid` is not passed to uWSGI       | `33`                   |
+| `UV_COMPILE_BYTECODE`    | Enable UV byte code compilation                                                                             | `1`                    |
+| `UWSGI_EXTRA`            | Extra parameter to pass to uWSGI command line - see below                                                   | empty                  |
+| `UWSGI_PROCESSES`        | Number of uWSGI processes to spawn                                                                          | `1`                    |
+| `UWSGI_THREADS`          | Number of uWSGI threads for each processes                                                                  | `4`                    |
 
-Extra uWSGI parameters
-----------------------
+## OpenShift / random UID environments
+
+By default, the container starts uWSGI with `--uid $SERVICE_UID --gid $SERVICE_GID`.
+
+If your platform runs containers with an arbitrary non-root UID (for example OpenShift),
+you can disable passing these options independently by setting:
+
+```sh
+SERVICE_UID=
+SERVICE_GID=
+```
+
+Each empty variable suppresses only its corresponding argument.
+
+## Extra uWSGI parameters
 
 `UWSGI_EXTRA` does not support quoted arguments. For instance, `UWSGI_EXTRA: --parameter-name='my quoted value'` will expand to multiple parameters `--parameter-name='my`, `quoted` and `value'`, therefore it will try to load configuration file `quoted` and fail: `unable to load configuration from quoted`.
 
 If you wish to use quoted values (for `logformat` for instance), a workaround is to use a mounted `uwsgi.ini` file, for instance:
 
-  1. define `UWSGI_EXTRA: --ini=/etc/uwsgi.ini`
-  2. add the parameters in a `uwsgi.ini` file:
+1. define `UWSGI_EXTRA: --ini=/etc/uwsgi.ini`
+2. add the parameters in a `uwsgi.ini` file:
 
-      ```ini
-      [uwsgi]
-      logdate = %%Y-%%m-%%d %%H:%%M:%%S
-      logformat-strftime = true
-      logformat = [%(ftime)] "%(method) %(uri) %(proto)" %(status)
-      ```
+    ```ini
+    [uwsgi]
+    logdate = %%Y-%%m-%%d %%H:%%M:%%S
+    logformat-strftime = true
+    logformat = [%(ftime)] "%(method) %(uri) %(proto)" %(status)
+    ```
 
-  3. mount that file in your Docker container
+3. mount that file in your Docker container

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -20,7 +20,14 @@ ENV PGSERVICEFILE="/srv/pg_service.conf"
 STOPSIGNAL SIGINT
 
 ENTRYPOINT ["/bin/sh", "-c", "\
+    UID_GID_ARGS=''; \
+    if [ -n \"$SERVICE_UID\" ]; then \
+      UID_GID_ARGS=\"$UID_GID_ARGS --uid $SERVICE_UID\"; \
+    fi; \
+    if [ -n \"$SERVICE_GID\" ]; then \
+      UID_GID_ARGS=\"$UID_GID_ARGS --gid $SERVICE_GID\"; \
+    fi; \
     HOME=/tmp uwsgi --http-socket :9090 --buffer-size $REQ_HEADER_BUFFER_SIZE --processes $UWSGI_PROCESSES \
     --threads $UWSGI_THREADS --plugins python3 $UWSGI_EXTRA --protocol uwsgi --wsgi-disable-file-wrapper \
-    --uid $SERVICE_UID --gid $SERVICE_GID --master --chdir /srv/qwc_service --virtualenv /srv/qwc_service/.venv \
+    $UID_GID_ARGS --master --chdir /srv/qwc_service --virtualenv /srv/qwc_service/.venv \
     --mount $SERVICE_MOUNTPOINT=server:app --manage-script-name"]

--- a/ubuntu/entrypoint.sh
+++ b/ubuntu/entrypoint.sh
@@ -13,7 +13,15 @@ else
 fi
 
 # NOTE: Set home to /tmp to ensure a writeable home directory exists
+UID_GID_ARGS=""
+if [ -n "$SERVICE_UID" ]; then
+  UID_GID_ARGS="$UID_GID_ARGS --uid $SERVICE_UID"
+fi
+if [ -n "$SERVICE_GID" ]; then
+  UID_GID_ARGS="$UID_GID_ARGS --gid $SERVICE_GID"
+fi
+
 HOME=/tmp uwsgi --http-socket :9090 --buffer-size $REQ_HEADER_BUFFER_SIZE --processes $UWSGI_PROCESSES \
     --threads $UWSGI_THREADS --plugins python3 $UWSGI_EXTRA --protocol uwsgi --wsgi-disable-file-wrapper \
-    --uid $SERVICE_UID --gid $SERVICE_GID --master --chdir /srv/qwc_service --virtualenv /srv/qwc_service/.venv \
+    $UID_GID_ARGS --master --chdir /srv/qwc_service --virtualenv /srv/qwc_service/.venv \
     --mount $SERVICE_MOUNTPOINT=server:app --manage-script-name


### PR DESCRIPTION
## Summary
- Make `--uid` and `--gid` arguments to uWSGI optional and independently controlled in both base images.
- Preserve backward compatibility by keeping existing defaults (`SERVICE_UID=33`, `SERVICE_GID=33`) and default runtime behavior unchanged.
- Document the new behavior in `README.md`, including OpenShift/arbitrary non-root UID usage.

## Why
In platforms like OpenShift, containers often run with an arbitrary non-root UID. In those cases, forcing uWSGI to call `setuid()`/`setgid()` can fail. This change allows disabling those flags when needed, while keeping the current behavior for existing users.

## What changed
- `ubuntu/entrypoint.sh`
  - Refactored uWSGI startup to avoid command duplication.
  - Added independent checks for `SERVICE_UID` and `SERVICE_GID`.
  - Appends `--uid` only when `SERVICE_UID` is non-empty.
  - Appends `--gid` only when `SERVICE_GID` is non-empty.

- `alpine/Dockerfile`
  - Refactored inline `ENTRYPOINT` command to avoid duplication.
  - Added the same independent `SERVICE_UID` / `SERVICE_GID` handling logic.
  - Uses a shared args variable that conditionally appends `--uid` and `--gid`.

- `README.md`
  - Updated env var descriptions for `SERVICE_UID` and `SERVICE_GID`.
  - Added section describing OpenShift/random UID environments.
  - Documented that each empty variable suppresses only its corresponding uWSGI argument.

## Behavior matrix
- `SERVICE_UID=33`, `SERVICE_GID=33` (default): passes `--uid` and `--gid` (unchanged behavior)
- `SERVICE_UID=`, `SERVICE_GID=33`: passes only `--gid`
- `SERVICE_UID=33`, `SERVICE_GID=`: passes only `--uid`
- `SERVICE_UID=`, `SERVICE_GID=`: passes neither `--uid` nor `--gid`

closes: #11 